### PR TITLE
Fix macro stubs on non-apple platforms

### DIFF
--- a/include/cmt/common.h
+++ b/include/cmt/common.h
@@ -32,7 +32,9 @@
 #  define mt_macCatalyst
 #  define mt_ios
 #  define mt_macos
-#  define mt_API_AVAILABLE(M, I)
+#  define MT_API_AVAILABLE(...)
+#  define MT_API_UNAVAILABLE(x)
+#  define API_UNAVAILABLE(...)
 #endif
 
 #endif /* cmt_common_h */


### PR DESCRIPTION
The MT_API_AVAILABLE, MT_API_UNAVAILABLE and API_UNAVAILABLE macros weren't defined properly on non-apple platforms, this adds the proper stubs